### PR TITLE
Add event task: inform users when ending date of an event is earlier …

### DIFF
--- a/src/main/java/command/AddEventCommand.java
+++ b/src/main/java/command/AddEventCommand.java
@@ -28,7 +28,7 @@ public class AddEventCommand extends Command {
         this.description = description;
         this.endDate = endDate;
         this.startDate = startDate;
-
+        assert !(endDate.isBefore(startDate)): "starting date should be before ending date";
     }
 
     /**

--- a/src/main/java/main/Parser.java
+++ b/src/main/java/main/Parser.java
@@ -55,11 +55,16 @@ public class Parser {
             } else if (command.startsWith("event")) {
                 String[] str2 = command.substring(6).split("/");
                 try {
-                    return new AddEventCommand(str2[0],
-                            LocalDate.parse(str2[1].substring(5, 15)), LocalDate.parse(str2[2].substring(3, 13)));
+                    LocalDate startDate = LocalDate.parse(str2[1].substring(5, 15));
+                    LocalDate endDate = LocalDate.parse(str2[2].substring(3, 13));
+                    if (endDate.isBefore(startDate)) {
+                        throw new DukeException("ending date cannot be before starting date");
+                    }
+                    return new AddEventCommand(str2[0], startDate, endDate);
                 } catch (DateTimeException e) {
                     throw new DukeException("Please enter a valid date in the form YYYY-MM-DD");
                 }
+
             } else {
                 throw new DukeException("Please input a valid command");
             }

--- a/src/main/java/main/TaskList.java
+++ b/src/main/java/main/TaskList.java
@@ -47,6 +47,7 @@ public class TaskList {
      * @return Task that is set as done.
      */
     public Task taskDone(int index) {
+        assert index > 0 && index < arrOfTask.size(): "index should be valid";
         Task t = arrOfTask.get(index);
         t.taskDone();
         return t;
@@ -59,6 +60,7 @@ public class TaskList {
      * @return Task that is set as not done.
      */
     public Task taskNotDone(int index) {
+        assert index > 0 && index < arrOfTask.size(): "index should be valid";
         Task t = arrOfTask.get(index);
         t.taskNotDone();
         return t;
@@ -71,6 +73,7 @@ public class TaskList {
      * @return Task that is deleted.
      */
     public Task deleteTask(int index) {
+        assert index > 0 && index < arrOfTask.size(): "index should be valid";
         Task t = arrOfTask.get(index);
         arrOfTask.remove(index);
         return t;
@@ -83,6 +86,7 @@ public class TaskList {
      * @return Task at index.
      */
     public Task getTaskAtIndex(int index) {
+        assert index > 0 && index < arrOfTask.size(): "index should be valid";
         return arrOfTask.get(index);
     }
 

--- a/src/main/java/task/Event.java
+++ b/src/main/java/task/Event.java
@@ -23,6 +23,7 @@ public class Event extends Task {
         super(name);
         this.startDate = startDate;
         this.endDate = endDate;
+        assert endDate.isAfter(startDate) || endDate.isEqual(startDate) : "end date should not be before start date";
     }
 
     /**


### PR DESCRIPTION
…than starting date of event

Currently, user can add an event with any ending and starting date.

Users should be informed of their mistake and be prompted to change.

Let's check for wrong dates and raise an exception when the mistake is detected.